### PR TITLE
Fix bugs, Split format version from package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "attpc_merger"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "eframe",
  "libattpc_merger",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "attpc_merger_cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "indicatif",
@@ -1892,7 +1892,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libattpc_merger"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bit-set 0.8.0",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Gordon McCann"]
 edition = "2021"
 license = "MIT"
 license-file = "LICENSE.txt"
-version = "0.2.0"
+version = "0.2.1"
 repository = "https://github.com/ATTPC/attpc_merger"
 readme = "README.md"
 

--- a/libattpc_merger/src/event_builder.rs
+++ b/libattpc_merger/src/event_builder.rs
@@ -66,7 +66,7 @@ impl EventBuilder {
     /// Used at the end of processing a run.
     /// Returns None if there were no frames left over.
     pub fn flush_final_event(&mut self) -> Option<Event> {
-        if self.frame_stack.is_empty() {
+        if !self.frame_stack.is_empty() {
             match Event::new(&self.pad_map, &self.frame_stack) {
                 Ok(event) => Some(event),
                 Err(_) => None,

--- a/libattpc_merger/src/hdf_writer.rs
+++ b/libattpc_merger/src/hdf_writer.rs
@@ -18,6 +18,7 @@ const FRIB_PHYSICS_NAME: &str = "frib_physics";
 
 // All event counters start from 0 by law
 const START_EVENT_NUMBER: u32 = 0;
+/// This is the version of the output format
 const FORMAT_VERSION: &str = "1.0";
 
 /// A simple struct which wraps around the hdf5-rust library.

--- a/libattpc_merger/src/hdf_writer.rs
+++ b/libattpc_merger/src/hdf_writer.rs
@@ -18,6 +18,7 @@ const FRIB_PHYSICS_NAME: &str = "frib_physics";
 
 // All event counters start from 0 by law
 const START_EVENT_NUMBER: u32 = 0;
+const FORMAT_VERSION: &str = "1.0";
 
 /// A simple struct which wraps around the hdf5-rust library.
 ///
@@ -54,7 +55,7 @@ impl HDFWriter {
         let run_path = path.file_stem().unwrap();
         let parent_file_path = stem.join(format!("{}.yml", run_path.to_string_lossy()));
 
-        let merger_version = format!("{}:{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        let merger_version = format!("{}:{}", env!("CARGO_PKG_NAME"), FORMAT_VERSION);
 
         let events_group = file_handle.create_group(EVENTS_NAME)?;
         events_group.new_attr::<u64>().create("min_event")?;

--- a/libattpc_merger/src/process.rs
+++ b/libattpc_merger/src/process.rs
@@ -21,8 +21,10 @@ fn flush_final_event(
 ) -> Result<(), ProcessorError> {
     if let Some(event) = evb.flush_final_event() {
         writer.write_event(event, event_counter)?;
-        writer.close()?;
+    } else {
+        spdlog::warn!("Last event was not flushed successfully!")
     }
+    writer.close()?;
     Ok(())
 }
 


### PR DESCRIPTION
Fix a bug in the final event flush. Split the version of the output format from the package version.